### PR TITLE
show init error BEFORE aborting

### DIFF
--- a/source/base/gs_engine.c
+++ b/source/base/gs_engine.c
@@ -73,8 +73,9 @@ gs_engine* gs_engine_construct( gs_application_desc app_desc )
 		{
 			if ( app_desc.init() != gs_result_success ) 
 			{
-				gs_assert( false );
+				// Show error before aborting
 				gs_println( "ERROR: Application failed to initialize." );
+				gs_assert( false );
 			}
 		}
 


### PR DESCRIPTION
This is a teeny tiny bug so I didn't want to have to bug you with an issue, but I moved the assert(false) to after the message so the user can figure out why it crashed without having to dive into the source like I did.