### PR TITLE
Make gs bool not to clash with stdbool.h.

### DIFF
--- a/gs.h
+++ b/gs.h
@@ -543,7 +543,9 @@ extern "C" {
 #ifdef __cplusplus
         typedef bool      b8;
 #else
+    #ifndef __bool_true_false_are_defined
         typedef _Bool     bool;
+    #endif
         typedef bool      b8;
 #endif
 


### PR DESCRIPTION
When we include stdbool.h and then gs.h _Bool gets redefined. Added this check to not redefine.
It happens in Nim generated code.

Maybe there's better way (why not use stdbool.h in Gunslinger?).
