### PR TITLE
Prefer built-in GLFW framebuffer function

### DIFF
--- a/impl/gs_platform_impl.h
+++ b/impl/gs_platform_impl.h
@@ -1505,11 +1505,7 @@ void gs_platform_set_window_sizev(uint32_t handle, gs_vec2 v)
 void gs_platform_framebuffer_size(uint32_t handle, uint32_t* w, uint32_t* h)
 {
     GLFWwindow* win = __glfw_window_from_handle(gs_engine_subsystem(platform), handle);
-    float xscale = 0.f, yscale = 0.f;
-    glfwGetWindowContentScale(win, &xscale, &yscale);
-    glfwGetWindowSize(win, (int32_t*)w, (int32_t*)h);
-    *w = (uint32_t)((float)*w * xscale);
-    *h = (uint32_t)((float)*h * yscale);
+    glfwGetFramebufferSize(win, (int32_t*)w, (int32_t*)h);
 }
 
 gs_vec2 gs_platform_framebuffer_sizev(uint32_t handle)


### PR DESCRIPTION
This fixes content scaling on windows.  See issue #32

glfwGetWindowSize already accounts for scaling, so, previously,
when the content scale was multiplied by the WindowSize it
caused the content to be rendered too big.

Before the change, this is what example 14 looked like with content scaling.

How it should look:
![100](https://user-images.githubusercontent.com/6413317/121264015-7c34b780-c884-11eb-9bc6-828782cde6fc.PNG)
How it looked with 150% content scale before this PR:
<img width="1156" alt="150" src="https://user-images.githubusercontent.com/6413317/121264023-7f2fa800-c884-11eb-8241-a4e35276ebd2.PNG">
How it looks with this PR:
<img width="1142" alt="pr150" src="https://user-images.githubusercontent.com/6413317/121264197-ca49bb00-c884-11eb-922e-49101821b3aa.PNG">

---
Additional info:
When comparing the 100% scale (first picture) with the post-PR 150% (third picture), notice that top row doesn't render the same, but the bottom row does.  This is because when "Scale and Layout" is set to a number different than 100% it changes the window width and height from what is set in the app description.  In this example, the window is set to 800x600, but gs_platform_window_sizev gets 1200x900.  I think this is handled internally in GLFW.  So the change in window size is what causes the top row to appear smaller.  I don't know if that should be in the scope of this PR or not.  I'm open to feedback.  Thanks!
