### PR TITLE
Add option to enable OpenGL debug messages

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -83,6 +83,7 @@ typedef struct gs_app_desc_t
     float frame_rate;             // Desired frame rate for application
     bool32 enable_vsync;          // Whether or not vsync is enabled
     bool32 is_running;            // Internal indicator for framework to know whether application should continue running
+    bool32 debug_gfx;             // Whether or not to enable debug logging for the graphics API
     void* user_data;              // Any user data for the application
 } gs_app_desc_t;
 ```

--- a/gs.h
+++ b/gs.h
@@ -3978,7 +3978,7 @@ typedef struct gs_opengl_video_settings_t
 typedef union gs_graphics_api_settings_t
 {
     gs_opengl_video_settings_t opengl;
-    int32_t                    dummy;   
+    bool32                     debug;
 } gs_graphics_api_settings_t;
 
 typedef struct gs_platform_video_settings_t
@@ -5158,6 +5158,7 @@ typedef struct gs_app_desc_t
     float frame_rate;
     bool32 enable_vsync;
     bool32 is_running;
+    bool32 debug_gfx;
     void* user_data;
 
     // Platform specific data
@@ -6185,6 +6186,9 @@ gs_engine_t* gs_engine_create(gs_app_desc_t app_desc)
 
         // Need to have video settings passed down from user
         gs_engine_subsystem(platform) = gs_platform_create();
+
+        // Enable graphics API debugging
+        gs_engine_subsystem(platform)->settings.video.graphics.debug = app_desc.debug_gfx;
 
         // Default initialization for platform here
         gs_platform_init(gs_engine_subsystem(platform));

--- a/impl/gs_platform_impl.h
+++ b/impl/gs_platform_impl.h
@@ -758,6 +758,12 @@ void gs_platform_init(gs_platform_t* pf)
                 // glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
                 // glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
                 // glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+                if (pf->settings.video.graphics.debug)
+                {
+                    glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
+                    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+                    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+                }
             #endif
             // glfwSwapInterval(platform->settings.video.vsync_enabled);
             // glfwSwapInterval(0);
@@ -1363,6 +1369,16 @@ void  gs_platform_enable_vsync(int32_t enabled)
     glfwSwapInterval(enabled ? 1 : 0);
 }
 
+/*== OpenGL debug callback == */
+void __gs_platform_gl_debug(GLenum source, GLenum type, GLuint id, GLenum severity,
+                            GLsizei len, const GLchar* msg, const void* user)
+{
+    if (severity != GL_DEBUG_SEVERITY_NOTIFICATION)
+    {
+        gs_println("GL: %s", msg);
+    }
+}
+
 /*== Platform Window == */
 
 void* gs_platform_create_window_internal(const char* title, uint32_t width, uint32_t height)
@@ -1403,6 +1419,10 @@ void* gs_platform_create_window_internal(const char* title, uint32_t width, uint
             case GS_PLATFORM_VIDEO_DRIVER_TYPE_OPENGL: 
             {
                 gs_println("OpenGL Version: %s", glGetString(GL_VERSION));
+                if (gs_engine_subsystem(platform)->settings.video.graphics.debug)
+                {
+                    glDebugMessageCallback(__gs_platform_gl_debug, NULL);
+                }
             } break;
 
             default: break;


### PR DESCRIPTION
Adds the option to request a debug OpenGL context by setting `debug_gfx` in `gs_app_desc_t`.