### PR TITLE
Fix the GitHub links on the examples.

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
               <p class="card-text" style="color: white">Hello, Gunslinger</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/00_hello_gs"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_platform/window/basic_window"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -194,7 +194,7 @@
               <p class="card-text" style="color: white">Simple Triangle</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/02_simple_triangle"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_graphics/simple_triangle"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -206,8 +206,8 @@
 
         <!-- Uniforms -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/03_uniforms/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/03_uniforms/bin/App.html">
                 <img src="examples/03_uniforms/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Uniforms</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -217,7 +217,7 @@
               <p class="card-text" style="color: white">Uniforms</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/03_uniforms"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_graphics/uniforms"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -229,8 +229,8 @@
 
         <!-- Simple Texture -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/04_simple_texture/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/04_simple_texture/bin/App.html">
                 <img src="examples/04_simple_texture/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Simple Texture</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -240,7 +240,7 @@
               <p class="card-text" style="color: white">Simple Texture</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/04_simple_texture"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_graphics/simple_texture"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -252,7 +252,7 @@
 
         <!-- Non-Interleaved Data -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
             <a class="example" href = "examples/06_non_interleaved_data/bin/App.html">
                 <img src="examples/06_non_interleaved_data/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Non-Interleaved Data</title>
@@ -263,7 +263,7 @@
               <p class="card-text" style="color: white">Non-Interleaved Vertex Data</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/06_non_interleaved_data"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_graphics/non_interleaved_data"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -275,8 +275,8 @@
 
         <!-- Instancing -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/07_instancing/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/07_instancing/bin/App.html">
                 <img src="examples/07_instancing/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Instancing</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -286,7 +286,7 @@
               <p class="card-text" style="color: white">Instancing</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/07_instancing"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_graphics/instancing"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -298,8 +298,8 @@
 
         <!-- Frame Buffer -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/09_frame_buffer/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/09_frame_buffer/bin/App.html">
                 <img src="examples/09_frame_buffer/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Frame Buffer</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -309,7 +309,7 @@
               <p class="card-text" style="color: white">FrameBuffer</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/09_frame_buffer"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_graphics/frame_buffer"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -321,8 +321,8 @@
 
         <!-- Non-Interleave Instancing -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/10_non_interleave_instancing/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/10_non_interleave_instancing/bin/App.html">
                 <img src="examples/10_non_interleave_instancing/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Non-Interleave Instancing</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -332,7 +332,7 @@
               <p class="card-text" style="color: white">Non-Interleaved Instancing</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/10_non_interleave_instancing"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_graphics/non_interleave_instancing"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -344,8 +344,8 @@
 
         <!-- Uniform Buffers -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/19_uniform_buffers/bin/App.html">
+          <div class"=card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/19_uniform_buffers/bin/App.html">
                 <img src="examples/19_uniform_buffers/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Uniform Buffers</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -355,7 +355,7 @@
               <p class="card-text" style="color: white">Uniform Buffers</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/19_uniform_buffers"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_graphics/uniform_buffers"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -367,8 +367,8 @@
 
         <!-- Uniforms Advanced -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/20_uniforms_advanced/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/20_uniforms_advanced/bin/App.html">
                 <img src="examples/20_uniforms_advanced/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Uniforms Advanced</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -378,7 +378,7 @@
               <p class="card-text" style="color: white">Uniforms Advanced</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/20_uniforms_advanced"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_graphics/uniforms_advanced"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -390,8 +390,8 @@
 
         <!-- Stencil Test -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/21_stencil_test/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/21_stencil_test/bin/App.html">
                 <img src="examples/21_stencil_test/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Stencil Test</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -401,7 +401,7 @@
               <p class="card-text" style="color: white">Stencil Test</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/21_stencil_test"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_graphics/stencil_test"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -422,8 +422,8 @@
 
         <!-- Audio -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/08_audio/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/08_audio/bin/App.html">
                 <img src="examples/08_audio/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Audio</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -433,7 +433,7 @@
               <p class="card-text" style="color: white">Audio</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/08_audio"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_core_audio/audio"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -454,8 +454,8 @@
 
         <!-- Collision Detection -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/23_collision_detection/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/23_collision_detection/bin/App.html">
                 <img src="examples/23_collision_detection/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Collision Detection</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -465,7 +465,7 @@
               <p class="card-text" style="color: white">Collision Detection</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/23_collision_detection"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_util_physics/collision_detection"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -486,7 +486,7 @@
 
         <!-- Immediate Draw -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
             <a class="example" href = "examples/14_immediate_draw/bin/App.html">
                 <img src="examples/14_immediate_draw/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Immediate Draw</title>
@@ -497,7 +497,7 @@
               <p class="card-text" style="color: white">Immediate Draw Util</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/14_immediate_draw"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_util_immediate_draw/immediate_draw"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -509,8 +509,8 @@
 
         <!-- Asset Manager -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/12_asset_manager/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/12_asset_manager/bin/App.html">
                 <img src="examples/12_asset_manager/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Asset Manager</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -520,7 +520,7 @@
               <p class="card-text" style="color: white">Asset Manager</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/12_asset_manager"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_util_assets/asset_manager"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -532,8 +532,8 @@
 
         <!-- Nuklear Gui -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/16_nuklear_gui/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/16_nuklear_gui/bin/App.html">
                 <img src="examples/16_nuklear_gui/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Nuklear Gui</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -543,7 +543,7 @@
               <p class="card-text" style="color: white">Nuklear Gui</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/16_nuklear_gui"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_demos/nuklear_gui"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -555,8 +555,8 @@
 
         <!-- MicroUI -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/24_microui/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/24_microui/bin/App.html">
                 <img src="examples/24_microui/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Micro UI</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -566,7 +566,7 @@
               <p class="card-text" style="color: white">Micro UI</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/24_microui"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_demos/microui"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -578,8 +578,8 @@
 
         <!-- Flecs -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/18_flecs/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/18_flecs/bin/App.html">
                 <img src="examples/18_flecs/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>Flecs</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -589,7 +589,7 @@
               <p class="card-text" style="color: white">Flecs</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/18_flecs"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_demos/flecs"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -601,8 +601,8 @@
 
         <!-- FPS Camera -->
         <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/22_first_person_camera/bin/App.html">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/22_first_person_camera/bin/App.html">
                 <img src="examples/22_first_person_camera/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>FPS Camera</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -612,7 +612,7 @@
               <p class="card-text" style="color: white">FPS Camera (Raylib Port)</p>
               <div class="d-flex justify-content-between align-items-center">
                 <div class="btn-group">
-                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/22_first_person_camera"> 
+                  <a href="https://github.com/MrFrenik/gs_examples/tree/main/ex_demos/first_person_camera"> 
                     <button type="button" class="btn btn-sm btn-outline-secondary">Github</button>
                   </a>
                 </div>
@@ -623,9 +623,10 @@
         </div>
 
         <!-- Pong -->
-        <div class="col">
-          <div class =card shadow-sm" style="background-color: rgb(45, 45, 45)">
-            <a class="example" href = "examples/25_pong/bin/App.html">
+        <!-- NOTE (quou): I'm not sure where the pong example is located on the gs_examples repository, does it still exist? -->
+    <!--    <div class="col">
+          <div class="card shadow-sm" style="background-color: rgb(45, 45, 45)">
+            <a class="example" href="examples/25_pong/bin/App.html">
                 <img src="examples/25_pong/screen_shot.png" class="bd-placeholder-img card-img-top" width="100%" height="225" xmlns="http://www.w3.org/2000/svg" role="button" aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
                 <title>FPS Camera</title>
                 <rect width="100%" height="100%" fill="#55595c"/>
@@ -640,10 +641,10 @@
                   </a>
                 </div>
                 <!-- <small class="text-muted">9 mins</small> -->
-              </div>
+             <!-- </div>
             </div>
           </div>
-        </div>
+        </div> -->
 
       </div>
     </div>


### PR DESCRIPTION
All of the example GitHub links were out of date on the website. For the most part, that's now fixed, however I couldn't find where the pong example is located. Was it removed?