### PR TITLE
General graphics command buffer

### DIFF
--- a/gs.h
+++ b/gs.h
@@ -6136,6 +6136,12 @@ typedef struct gs_graphics_info_t
 // Graphics Interface
 ==========================*/
 
+//
+/* #ifndef GS_GRAPHICS_IMPL_CUSTOM */
+	typedef gs_command_buffer_t				gs_graphics_command_buffer_t;
+	#define gs_graphics_command_buffer_new	gs_command_buffer_new
+/* #endif // GS_GRAPHICS_IMPL_CUSTOM */
+
 typedef struct gs_graphics_t
 {
     void* user_data;                // For internal use
@@ -6173,7 +6179,7 @@ typedef struct gs_graphics_t
         void (* texture_update)(gs_handle(gs_graphics_texture_t) hndl, gs_graphics_texture_desc_t* desc);
 
         // Submission (Main Thread)
-        void (* command_buffer_submit)(gs_command_buffer_t* cb);
+        void (* command_buffer_submit)(gs_graphics_command_buffer_t* cb);
 
     } api;                          // Interface for stable access across .dll boundaries
 } gs_graphics_t;
@@ -6229,22 +6235,22 @@ GS_API_DECL void gs_graphics_pipeline_desc_query(gs_handle(gs_graphics_pipeline_
 GS_API_DECL void gs_graphics_texture_desc_query(gs_handle(gs_graphics_texture_t) hndl, gs_graphics_texture_desc_t* out); 
 
 // Resource In-Flight Update
-GS_API_DECL void gs_graphics_texture_request_update(gs_command_buffer_t* cb, gs_handle(gs_graphics_texture_t) hndl, gs_graphics_texture_desc_t* desc);
-GS_API_DECL void gs_graphics_vertex_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_graphics_vertex_buffer_t) hndl, gs_graphics_vertex_buffer_desc_t* desc);
-GS_API_DECL void gs_graphics_index_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_graphics_index_buffer_t) hndl, gs_graphics_index_buffer_desc_t* desc);
-GS_API_DECL void gs_graphics_uniform_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_graphics_uniform_buffer_t) hndl, gs_graphics_uniform_buffer_desc_t* desc);
-GS_API_DECL void gs_graphics_storage_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_graphics_storage_buffer_t) hndl, gs_graphics_storage_buffer_desc_t* desc);
+GS_API_DECL void gs_graphics_texture_request_update(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_texture_t) hndl, gs_graphics_texture_desc_t* desc);
+GS_API_DECL void gs_graphics_vertex_buffer_request_update(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_vertex_buffer_t) hndl, gs_graphics_vertex_buffer_desc_t* desc);
+GS_API_DECL void gs_graphics_index_buffer_request_update(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_index_buffer_t) hndl, gs_graphics_index_buffer_desc_t* desc);
+GS_API_DECL void gs_graphics_uniform_buffer_request_update(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_uniform_buffer_t) hndl, gs_graphics_uniform_buffer_desc_t* desc);
+GS_API_DECL void gs_graphics_storage_buffer_request_update(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_storage_buffer_t) hndl, gs_graphics_storage_buffer_desc_t* desc);
 
 // Pipeline / Pass / Bind / Draw
-GS_API_DECL void gs_graphics_renderpass_begin(gs_command_buffer_t* cb, gs_handle(gs_graphics_renderpass_t) hndl);
-GS_API_DECL void gs_graphics_renderpass_end(gs_command_buffer_t* cb);
-GS_API_DECL void gs_graphics_set_viewport(gs_command_buffer_t* cb, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
-GS_API_DECL void gs_graphics_set_view_scissor(gs_command_buffer_t* cb, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
-GS_API_DECL void gs_graphics_clear(gs_command_buffer_t* cb, gs_graphics_clear_desc_t* desc);
-GS_API_DECL void gs_graphics_pipeline_bind(gs_command_buffer_t* cb, gs_handle(gs_graphics_pipeline_t) hndl);
-GS_API_DECL void gs_graphics_apply_bindings(gs_command_buffer_t* cb, gs_graphics_bind_desc_t* binds);
-GS_API_DECL void gs_graphics_draw(gs_command_buffer_t* cb, gs_graphics_draw_desc_t* desc);
-GS_API_DECL void gs_graphics_dispatch_compute(gs_command_buffer_t* cb, uint32_t num_x_groups, uint32_t num_y_groups, uint32_t num_z_groups);
+GS_API_DECL void gs_graphics_renderpass_begin(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_renderpass_t) hndl);
+GS_API_DECL void gs_graphics_renderpass_end(gs_graphics_command_buffer_t* cb);
+GS_API_DECL void gs_graphics_set_viewport(gs_graphics_command_buffer_t* cb, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
+GS_API_DECL void gs_graphics_set_view_scissor(gs_graphics_command_buffer_t* cb, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
+GS_API_DECL void gs_graphics_clear(gs_graphics_command_buffer_t* cb, gs_graphics_clear_desc_t* desc);
+GS_API_DECL void gs_graphics_pipeline_bind(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_pipeline_t) hndl);
+GS_API_DECL void gs_graphics_apply_bindings(gs_graphics_command_buffer_t* cb, gs_graphics_bind_desc_t* binds);
+GS_API_DECL void gs_graphics_draw(gs_graphics_command_buffer_t* cb, gs_graphics_draw_desc_t* desc);
+GS_API_DECL void gs_graphics_dispatch_compute(gs_graphics_command_buffer_t* cb, uint32_t num_x_groups, uint32_t num_y_groups, uint32_t num_z_groups);
 
 // Submission (Main Thread)
 #define gs_graphics_command_buffer_submit(CB)  gs_graphics()->api.command_buffer_submit((CB))

--- a/impl/gs_graphics_impl.h
+++ b/impl/gs_graphics_impl.h
@@ -1282,7 +1282,7 @@ GS_API_DECL void
 gs_graphics_vertex_buffer_update_impl(gs_handle(gs_graphics_vertex_buffer_t) hndl, gs_graphics_vertex_buffer_desc_t* desc)
 { 
     /*
-    void __gs_graphics_update_buffer_internal(gs_command_buffer_t* cb, 
+    void __gs_graphics_update_buffer_internal(gs_graphics_command_buffer_t* cb, 
         uint32_t id, 
         gs_graphics_buffer_type type,
         gs_graphics_buffer_usage_type usage, 
@@ -1373,7 +1373,7 @@ do {\
 
 /* Command Buffer Ops: Pipeline / Pass / Bind / Draw */
 GS_API_DECL void 
-gs_graphics_renderpass_begin(gs_command_buffer_t* cb, gs_handle(gs_graphics_renderpass_t) hndl)
+gs_graphics_renderpass_begin(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_renderpass_t) hndl)
 {
     __ogl_push_command(cb, GS_OPENGL_OP_BEGIN_RENDER_PASS, {
         gs_byte_buffer_write(&cb->commands, uint32_t, hndl.id);
@@ -1381,7 +1381,7 @@ gs_graphics_renderpass_begin(gs_command_buffer_t* cb, gs_handle(gs_graphics_rend
 }
 
 GS_API_DECL void 
-gs_graphics_renderpass_end(gs_command_buffer_t* cb)
+gs_graphics_renderpass_end(gs_graphics_command_buffer_t* cb)
 {
     __ogl_push_command(cb, GS_OPENGL_OP_END_RENDER_PASS, {
         // Nothing...
@@ -1389,7 +1389,7 @@ gs_graphics_renderpass_end(gs_command_buffer_t* cb)
 }
 
 GS_API_DECL void 
-gs_graphics_clear(gs_command_buffer_t* cb, gs_graphics_clear_desc_t* desc)
+gs_graphics_clear(gs_graphics_command_buffer_t* cb, gs_graphics_clear_desc_t* desc)
 {
     __ogl_push_command(cb, GS_OPENGL_OP_CLEAR, {
         uint32_t count = !desc->actions ? 0 : !desc->size ? 1 : (uint32_t)((size_t)desc->size / (size_t)sizeof(gs_graphics_clear_action_t));
@@ -1401,7 +1401,7 @@ gs_graphics_clear(gs_command_buffer_t* cb, gs_graphics_clear_desc_t* desc)
 }
 
 GS_API_DECL void 
-gs_graphics_set_viewport(gs_command_buffer_t* cb, uint32_t x, uint32_t y, uint32_t w, uint32_t h)
+gs_graphics_set_viewport(gs_graphics_command_buffer_t* cb, uint32_t x, uint32_t y, uint32_t w, uint32_t h)
 {
     __ogl_push_command(cb, GS_OPENGL_OP_SET_VIEWPORT, {
         gs_byte_buffer_write(&cb->commands, uint32_t, x);
@@ -1412,7 +1412,7 @@ gs_graphics_set_viewport(gs_command_buffer_t* cb, uint32_t x, uint32_t y, uint32
 }
 
 GS_API_DECL void 
-gs_graphics_set_view_scissor(gs_command_buffer_t* cb, uint32_t x, uint32_t y, uint32_t w, uint32_t h)
+gs_graphics_set_view_scissor(gs_graphics_command_buffer_t* cb, uint32_t x, uint32_t y, uint32_t w, uint32_t h)
 { 
     __ogl_push_command(cb, GS_OPENGL_OP_SET_VIEW_SCISSOR, {
         gs_byte_buffer_write(&cb->commands, uint32_t, x);
@@ -1423,7 +1423,7 @@ gs_graphics_set_view_scissor(gs_command_buffer_t* cb, uint32_t x, uint32_t y, ui
 }
 
 GS_API_DECL void 
-gs_graphics_texture_request_update(gs_command_buffer_t* cb, gs_handle(gs_graphics_texture_t) hndl, gs_graphics_texture_desc_t* desc)
+gs_graphics_texture_request_update(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_texture_t) hndl, gs_graphics_texture_desc_t* desc)
 {
     // Write command
     gs_byte_buffer_write(&cb->commands, uint32_t, (uint32_t)GS_OPENGL_OP_REQUEST_TEXTURE_UPDATE);
@@ -1458,7 +1458,7 @@ gs_graphics_texture_request_update(gs_command_buffer_t* cb, gs_handle(gs_graphic
     gs_byte_buffer_write_bulk(&cb->commands, *desc->data, total_size);
 }
 
-void __gs_graphics_update_buffer_internal(gs_command_buffer_t* cb, 
+void __gs_graphics_update_buffer_internal(gs_graphics_command_buffer_t* cb, 
     uint32_t id, 
     gs_graphics_buffer_type type,
     gs_graphics_buffer_usage_type usage, 
@@ -1488,7 +1488,7 @@ void __gs_graphics_update_buffer_internal(gs_command_buffer_t* cb,
 }
 
 GS_API_DECL void 
-gs_graphics_vertex_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_graphics_vertex_buffer_t) hndl, gs_graphics_vertex_buffer_desc_t* desc)
+gs_graphics_vertex_buffer_request_update(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_vertex_buffer_t) hndl, gs_graphics_vertex_buffer_desc_t* desc)
 {
     gsgl_data_t* ogl = (gsgl_data_t*)gs_subsystem(graphics)->user_data;
 
@@ -1499,7 +1499,7 @@ gs_graphics_vertex_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_g
 }
 
 GS_API_DECL void 
-gs_graphics_index_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_graphics_index_buffer_t) hndl, gs_graphics_index_buffer_desc_t* desc)
+gs_graphics_index_buffer_request_update(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_index_buffer_t) hndl, gs_graphics_index_buffer_desc_t* desc)
 {
     gsgl_data_t* ogl = (gsgl_data_t*)gs_subsystem(graphics)->user_data;
 
@@ -1510,7 +1510,7 @@ gs_graphics_index_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_gr
 }
 
 GS_API_DECL void 
-gs_graphics_uniform_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_graphics_uniform_buffer_t) hndl, gs_graphics_uniform_buffer_desc_t* desc)
+gs_graphics_uniform_buffer_request_update(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_uniform_buffer_t) hndl, gs_graphics_uniform_buffer_desc_t* desc)
 {
     gsgl_data_t* ogl = (gsgl_data_t*)gs_subsystem(graphics)->user_data;
 
@@ -1521,7 +1521,7 @@ gs_graphics_uniform_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_
 }
 
 GS_API_DECL void 
-gs_graphics_storage_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_graphics_storage_buffer_t) hndl, gs_graphics_storage_buffer_desc_t* desc)
+gs_graphics_storage_buffer_request_update(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_storage_buffer_t) hndl, gs_graphics_storage_buffer_desc_t* desc)
 {
     gsgl_data_t* ogl = (gsgl_data_t*)gs_subsystem(graphics)->user_data;
 
@@ -1531,7 +1531,7 @@ gs_graphics_storage_buffer_request_update(gs_command_buffer_t* cb, gs_handle(gs_
     __gs_graphics_update_buffer_internal(cb, hndl.id, GS_GRAPHICS_BUFFER_SHADER_STORAGE, desc->usage, desc->size, desc->update.offset, desc->update.type, desc->data);
 }
 
-void gs_graphics_apply_bindings(gs_command_buffer_t* cb, gs_graphics_bind_desc_t* binds)
+void gs_graphics_apply_bindings(gs_graphics_command_buffer_t* cb, gs_graphics_bind_desc_t* binds)
 {
     gsgl_data_t* ogl = (gsgl_data_t*)gs_subsystem(graphics)->user_data;
 
@@ -1625,7 +1625,7 @@ void gs_graphics_apply_bindings(gs_command_buffer_t* cb, gs_graphics_bind_desc_t
     };
 }
 
-void gs_graphics_pipeline_bind(gs_command_buffer_t* cb, gs_handle(gs_graphics_pipeline_t) hndl)
+void gs_graphics_pipeline_bind(gs_graphics_command_buffer_t* cb, gs_handle(gs_graphics_pipeline_t) hndl)
 {
     // NOTE(john): Not sure if this is safe in the future, since the data for pipelines is on the main thread and MIGHT be tampered with on a separate thread.
     __ogl_push_command(cb, GS_OPENGL_OP_BIND_PIPELINE, {
@@ -1633,7 +1633,7 @@ void gs_graphics_pipeline_bind(gs_command_buffer_t* cb, gs_handle(gs_graphics_pi
     });
 }
 
-void gs_graphics_draw(gs_command_buffer_t* cb, gs_graphics_draw_desc_t* desc)
+void gs_graphics_draw(gs_graphics_command_buffer_t* cb, gs_graphics_draw_desc_t* desc)
 {
     __ogl_push_command(cb, GS_OPENGL_OP_DRAW, {
         gs_byte_buffer_write(&cb->commands, uint32_t, desc->start);
@@ -1645,7 +1645,7 @@ void gs_graphics_draw(gs_command_buffer_t* cb, gs_graphics_draw_desc_t* desc)
     });
 }
 
-void gs_graphics_dispatch_compute(gs_command_buffer_t* cb, uint32_t num_x_groups, uint32_t num_y_groups, uint32_t num_z_groups)
+void gs_graphics_dispatch_compute(gs_graphics_command_buffer_t* cb, uint32_t num_x_groups, uint32_t num_y_groups, uint32_t num_z_groups)
 {
     __ogl_push_command(cb, GS_OPENGL_OP_DISPATCH_COMPUTE, {
         gs_byte_buffer_write(&cb->commands, uint32_t, num_x_groups);
@@ -1655,7 +1655,7 @@ void gs_graphics_dispatch_compute(gs_command_buffer_t* cb, uint32_t num_x_groups
 }
 
 /* Submission (Main Thread) */
-void gs_graphics_command_buffer_submit_impl(gs_command_buffer_t* cb)
+void gs_graphics_command_buffer_submit_impl(gs_graphics_command_buffer_t* cb)
 {
     /*
         // Structure of command: 


### PR DESCRIPTION
The current OGL graphics implementation uses a standard `gs_command_buffer_t` as its command buffer. This works since OGL is not thread-safe, and so the command buffer here is simply used to defer API calls onto a single thread. However, this scheme is not ideal, as different graphics APIs have their own concept of a command buffer which is managed on a per-API basis. Furthermore, such APIs allow for legitimate thread safety when using such command buffers, and so we need not defer calls like the OGL implementation. Since `gs_command_buffer_t` is decoupled from the graphics subsystem, there is no way of handling such command buffer work on a per-API basis. Currently, the user simply passes in a `gs_command_buffer_t *` to the graphics interface, and thus the graphics implementation has no way of managing it appropriately. As such, introducing a generic graphics command buffer type for the graphics interface would allow users to define their own custom graphics command buffer when writing graphics API backends.

Hence, I've introduced a new `gs_graphics_command_buffer_t` type that allows for this sort of behaviour to be possible. I've also added a `gs_graphics_command_buffer_new()` for creating such a command buffer, and I've changed the appropriate `gs_graphics_XXX()` functions to use this command buffer instead of the default one.

Currently, for the default OGL implementation, this new type and function simply alias to the default `gs_command_buffer_t`. In the future, when alternative graphics backends are implemented, a simple `#ifdef/#ifndef` check can be used to choose the correct command buffer type for each API. I've also tested this change with the existing gs_examples (`ex_core_graphics`) and haven't encountered any issues.
