### PR TITLE
Update gs_audio_impl.h

### DIFF
--- a/impl/gs_audio_impl.h
+++ b/impl/gs_audio_impl.h
@@ -153,8 +153,8 @@ gs_handle(gs_audio_source_t) gs_audio_load_from_file(const char* file_path)
     }
 
     char ext[64] = gs_default_val();
-    gs_util_str_to_lower(file_path, ext, sizeof(ext));
-    gs_platform_file_extension(ext, sizeof(ext), ext);
+    gs_platform_file_extension(ext, sizeof(ext), file_path);
+    gs_util_str_to_lower(ext, ext, sizeof(ext));
     gs_println("Audio: File Extension: %s", ext);
 
     // Load OGG data


### PR DESCRIPTION
fix bug where file_path of an audio file is limited to 63 characters