### PR TITLE
fix gcc/clang compiler warnings

### DIFF
--- a/gs.h
+++ b/gs.h
@@ -7925,7 +7925,7 @@ gs_asset_texture_load_from_file(const char* path, void* out, gs_graphics_texture
     stbi_set_flip_vertically_on_load(t->desc.flip_y);
     *t->desc.data = (uint8_t*)stbi_load_from_file(f, (int32_t*)&t->desc.width, (int32_t*)&t->desc.height, (int32_t*)&comp, STBI_rgb_alpha);
 
-    if (!t->desc.data) {
+    if (!*t->desc.data) {
         fclose(f);
         return false;
     }
@@ -7972,7 +7972,7 @@ bool gs_asset_texture_load_from_memory(const void* memory, size_t sz, void* out,
     // Load texture data
     int32_t num_comps = 0;
     bool32_t loaded = gs_util_load_texture_data_from_memory(memory, sz, (int32_t*)&t->desc.width, 
-        (int32_t*)&t->desc.height, (uint32_t*)&num_comps, (void**)&t->desc.data, t->desc.flip_y);
+        (int32_t*)&t->desc.height, (uint32_t*)&num_comps, t->desc.data, t->desc.flip_y);
 
     if (!loaded) {
         return false;
@@ -7981,7 +7981,7 @@ bool gs_asset_texture_load_from_memory(const void* memory, size_t sz, void* out,
     t->hndl = gs_graphics_texture_create(&t->desc);
 
     if (!keep_data) {
-        gs_free(t->desc.data);
+        gs_free(*t->desc.data);
         *t->desc.data = NULL;
     }
 
@@ -8721,7 +8721,7 @@ gs_lexer_c_next_token(gs_lexer_t* lex)
                     )
                     {
                         // Grab decimal
-                        num_decimals = lex->at[0] == '.' ? num_decimals++ : num_decimals;
+                        num_decimals = lex->at[0] == '.' ? num_decimals + 1 : num_decimals;
 
                         //Increment
                         lex->at++;
@@ -8818,7 +8818,7 @@ gs_lexer_c_next_token(gs_lexer_t* lex)
 					)
 					{
 						// Grab decimal
-						num_decimals = lex->at[0] == '.' ? num_decimals++ : num_decimals;
+						num_decimals = lex->at[0] == '.' ? num_decimals + 1 : num_decimals;
 
 						//Increment
 						lex->at++;

--- a/util/gs_gfxt.h
+++ b/util/gs_gfxt.h
@@ -2349,33 +2349,34 @@ bool gs_parse_code(gs_lexer_t* lex, gs_gfxt_pipeline_desc_t* desc, gs_ppd_t* ppd
         {
             case GS_TOKEN_IDENTIFIER:
             {
+                // evil replace a const char*
                 if (gs_token_compare_text(&tkn, "GS_GFXT_UNIFORM_MODEL_VIEW_PROJECTION_MATRIX"))
                 {
-                    gs_util_string_replace(tkn.text, tkn.len, GS_GFXT_UNIFORM_MODEL_VIEW_PROJECTION_MATRIX, (char)32);
+                    gs_util_string_replace((char*)tkn.text, tkn.len, GS_GFXT_UNIFORM_MODEL_VIEW_PROJECTION_MATRIX, (char)32);
                 }
                 else if (gs_token_compare_text(&tkn, "GS_GFXT_UNIFORM_VIEW_PROJECTION_MATRIX"))
                 {
-                    gs_util_string_replace(tkn.text, tkn.len, GS_GFXT_UNIFORM_VIEW_PROJECTION_MATRIX, (char)32);
+                    gs_util_string_replace((char*)tkn.text, tkn.len, GS_GFXT_UNIFORM_VIEW_PROJECTION_MATRIX, (char)32);
                 }
                 else if (gs_token_compare_text(&tkn, "GS_GFXT_UNIFORM_MODEL_MATRIX"))
                 {
-                    gs_util_string_replace(tkn.text, tkn.len, GS_GFXT_UNIFORM_MODEL_MATRIX, (char)32);
+                    gs_util_string_replace((char*)tkn.text, tkn.len, GS_GFXT_UNIFORM_MODEL_MATRIX, (char)32);
                 }
                 else if (gs_token_compare_text(&tkn, "GS_GFXT_UNIFORM_INVERSE_MODEL_MATRIX"))
                 {
-                    gs_util_string_replace(tkn.text, tkn.len, GS_GFXT_UNIFORM_INVERSE_MODEL_MATRIX, (char)32);
+                    gs_util_string_replace((char*)tkn.text, tkn.len, GS_GFXT_UNIFORM_INVERSE_MODEL_MATRIX, (char)32);
                 }
                 else if (gs_token_compare_text(&tkn, "GS_GFXT_UNIFORM_VIEW_MATRIX"))
                 {
-                    gs_util_string_replace(tkn.text, tkn.len, GS_GFXT_UNIFORM_VIEW_MATRIX, (char)32);
+                    gs_util_string_replace((char*)tkn.text, tkn.len, GS_GFXT_UNIFORM_VIEW_MATRIX, (char)32);
                 }
                 else if (gs_token_compare_text(&tkn, "GS_GFXT_UNIFORM_PROJECTION_MATRIX"))
                 {
-                    gs_util_string_replace(tkn.text, tkn.len, GS_GFXT_UNIFORM_PROJECTION_MATRIX, (char)32);
+                    gs_util_string_replace((char*)tkn.text, tkn.len, GS_GFXT_UNIFORM_PROJECTION_MATRIX, (char)32);
                 }
                 else if (gs_token_compare_text(&tkn, "GS_GFXT_UNIFORM_TIME"))
                 {
-                    gs_util_string_replace(tkn.text, tkn.len, GS_GFXT_UNIFORM_TIME, (char)32);
+                    gs_util_string_replace((char*)tkn.text, tkn.len, GS_GFXT_UNIFORM_TIME, (char)32);
                 }
             } break;
 
@@ -2397,7 +2398,8 @@ bool gs_parse_code(gs_lexer_t* lex, gs_gfxt_pipeline_desc_t* desc, gs_ppd_t* ppd
                             if (tkn.type == GS_TOKEN_STRING)
                             {
                                 memcpy(includes[iidx], tkn.text + 1, tkn.len - 2);
-                                gs_util_string_replace(tkn.text - ilen, tkn.len + ilen,
+                                // evil replace a const char*
+                                gs_util_string_replace((char*)tkn.text - ilen, tkn.len + ilen,
                                     " ", (char)32);
                                 iidx++;
                             }

--- a/util/gs_gui.h
+++ b/util/gs_gui.h
@@ -5478,7 +5478,7 @@ gs_gui_draw_text(gs_gui_context_t* ctx, gs_asset_font_t* font, const char *str,
     } while (0)
 
     // Draw shadow
-    if (shadow_x || shadow_y && shadow_color.a)
+    if ((shadow_x || shadow_y) && shadow_color.a)
     {
         DRAW_TEXT(str, gs_gui_rect(pos.x + (float)shadow_x, pos.y + (float)shadow_y, td.x, td.y), shadow_color);
     }
@@ -7246,8 +7246,8 @@ gs_gui_window_begin_ex(gs_gui_context_t * ctx, const char* title, gs_gui_rect_t 
         if (tab_bar->focus == tab_item->idx) 
         {
             cnt->flags |= GS_GUI_WINDOW_FLAGS_VISIBLE;
-            cnt->opt &= !GS_GUI_OPT_NOINTERACT; 
-            cnt->opt &= !GS_GUI_OPT_NOHOVER; 
+            cnt->opt &= ~GS_GUI_OPT_NOINTERACT;
+            cnt->opt &= ~GS_GUI_OPT_NOHOVER;
         }
         else
         {

--- a/util/gs_gui.h
+++ b/util/gs_gui.h
@@ -6317,7 +6317,7 @@ gs_gui_label_ex(gs_gui_context_t* ctx, const char* label, const gs_gui_selector_
     gs_gui_parse_id_tag(ctx, label, id_tag, sizeof(id_tag), opt);
     gs_gui_parse_label_tag(ctx, label, label_tag, sizeof(label_tag));
 
-	if (id_tag) gs_gui_push_id(ctx, id_tag, strlen(id_tag));
+	gs_gui_push_id(ctx, id_tag, strlen(id_tag));
 
     gs_gui_style_t style = gs_default_val();
     gs_gui_animation_t* anim = gs_gui_get_animation(ctx, id, desc, elementid); 
@@ -6341,7 +6341,7 @@ gs_gui_label_ex(gs_gui_context_t* ctx, const char* label, const gs_gui_selector_
 	gs_gui_update_control(ctx, id, r, 0x00); 
 	gs_gui_draw_control_text(ctx, label_tag, r, &style, 0x00); 
     gs_gui_pop_style(ctx, save);
-	if (id_tag) gs_gui_pop_id(ctx);
+	gs_gui_pop_id(ctx);
 
 	/* handle click */
     if (
@@ -6525,9 +6525,7 @@ gs_gui_button_ex(gs_gui_context_t* ctx, const char* label, const gs_gui_selector
     gs_gui_animation_t* anim = gs_gui_get_animation(ctx, id, desc, GS_GUI_ELEMENT_BUTTON);
 
 	// Push id if tag available
-	if (id_tag) {
-		gs_gui_push_id(ctx, id_tag, strlen(id_tag));
-	}
+    gs_gui_push_id(ctx, id_tag, strlen(id_tag));
 
     // Update anim (keep states locally within animation, only way to do this) 
     if (anim)
@@ -6567,7 +6565,7 @@ gs_gui_button_ex(gs_gui_context_t* ctx, const char* label, const gs_gui_selector
 
     gs_gui_pop_style(ctx, save);
 
-	if (id_tag) gs_gui_pop_id(ctx);
+	gs_gui_pop_id(ctx);
 
 	return res;
 }
@@ -6999,7 +6997,7 @@ static int32_t _gs_gui_header(gs_gui_context_t *ctx, const char *label, int32_t 
 	gs_gui_id id = gs_gui_get_id(ctx, id_tag, strlen(id_tag));
 	int32_t idx = gs_gui_pool_get(ctx, ctx->treenode_pool, GS_GUI_TREENODEPOOL_SIZE, id);
 
-    if (id_tag) gs_gui_push_id(ctx, id_tag, strlen(id_tag));
+    gs_gui_push_id(ctx, id_tag, strlen(id_tag));
 
 	active = (idx >= 0);
 	expanded = (opt & GS_GUI_OPT_EXPANDED) ? !active : active;
@@ -7060,7 +7058,7 @@ static int32_t _gs_gui_header(gs_gui_context_t *ctx, const char *label, int32_t 
 	r.w -= r.h - ctx->style->padding[GS_GUI_PADDING_BOTTOM]; 
 	gs_gui_draw_control_text(ctx, label_tag, r, &ctx->style_sheet->styles[GS_GUI_ELEMENT_TEXT][0x00], 0);
 
-    if (id_tag) gs_gui_pop_id(ctx);
+    gs_gui_pop_id(ctx);
 
 	return expanded ? GS_GUI_RES_ACTIVE : 0;
 } 
@@ -7160,9 +7158,7 @@ gs_gui_window_begin_ex(gs_gui_context_t * ctx, const char* title, gs_gui_rect_t 
     } 
 
     // Push id flag
-    if (id_tag) {
-        // cnt->flags |= GS_GUI_WINDOW_FLAGS_PUSH_ID;
-    }
+    // cnt->flags |= GS_GUI_WINDOW_FLAGS_PUSH_ID;
 
     if (cnt->flags & GS_GUI_WINDOW_FLAGS_FIRST_INIT) {
 	    memcpy(cnt->name, label_tag, 256);


### PR DESCRIPTION
I have
-Wno-missing-braces -Wno-switch -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-comment -Wno-unreachable-code-generic-assoc -Wno-initializer-overrides
on so there are probably more warnings, but I personally don't care about those.

Most of the warnings fixed in this PR are either bugs or likely unintended behavior.

Please check over the changes like always, thanks.
doing `if (constant_array) ...` might be intended, I've separated the PR into bugs and misc, hopefully it's easier to go through it that way.