### PR TITLE
Range fix on draw command

### DIFF
--- a/impl/gs_graphics_impl.h
+++ b/impl/gs_graphics_impl.h
@@ -2686,7 +2686,7 @@ void gs_graphics_command_buffer_submit_impl(gs_command_buffer_t* cb)
                 gs_byte_buffer_readc(&cb->commands, uint32_t, range_start);
                 gs_byte_buffer_readc(&cb->commands, uint32_t, range_end);
 
-                range_end = (range_end && range_end < range_start) ? range_end : count;
+                range_end = (range_end && range_end > range_start) ? range_end : start + count;
 
                 // Bind element buffer ranged
                 if (ogl->cache.ibo) {


### PR DESCRIPTION
I believe that this line is incorrect. It looks like it is supposed to correct the range given by the draw command, if it is invalid. From my interpretation, the line basically is saying:

> If the end of the range was provided in the draw command description, and the range end is before the start (thus an invalid range), use the provided range end. Else, use the count provided in the description as the end.

That makes no sense imo, and goes against what I see in the openGL [docs](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDrawRangeElementsBaseVertex.xhtml). The end of a range should never be before the start of a range.

I corrected the logic to say:

> If the end of the range was provided in the draw command description, and the range end is after the start (thus valid), use the provided range end. Otherwise, calculate a new range end based on the provided count.

I was pulling my hair out trying to figure out if I was doing something wrong lol. If this is intended behavior, it is pretty confusing, and I think some comments should be added to the `gs_graphics_draw_desc_t` struct. Love the framework btw, using it to learn a lot about C.



