### PR TITLE
Fix wrong canvas size used during emscripten init (squished UI)

### DIFF
--- a/impl/gs_platform_impl.h
+++ b/impl/gs_platform_impl.h
@@ -2546,8 +2546,8 @@ gs_platform_init(gs_platform_t* platform)
 
     // Just set this to defaults for now
     ems->canvas_name = "#canvas";
-    emscripten_set_canvas_element_size(ems->canvas_name, app->window.width, app->window.height);
     emscripten_get_element_css_size(ems->canvas_name, &ems->canvas_width, &ems->canvas_height);
+    emscripten_set_canvas_element_size(ems->canvas_name, ems->canvas_width, ems->canvas_height);
 
     // Set up callbacks
     emscripten_set_fullscreenchange_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, true, gs_ems_fullscreenchange_cb);


### PR DESCRIPTION
![Screenshot from 2024-07-17 14-06-30](https://github.com/user-attachments/assets/7c09ec8e-c896-42fc-8bac-a2fb2b067eb6)
