### PR TITLE
Multiple cgltf Nodes with base_color_texture Import, Skysphere matrix function

### DIFF
--- a/util/gs_gfxt.h
+++ b/util/gs_gfxt.h
@@ -417,7 +417,9 @@ void gs_gfxt_scene_pbr_draw(gs_command_buffer_t* cb, gs_gfxt_scene_t* scene, gs_
 GS_API_DECL 
 gs_gfxt_scene_t gs_gfxt_scene_new()
 {
-  const char* pbr_basic_path = "./third_party/include/gs/util/pbr_basic.sf";
+  // maybe we can ship this standard pipeline with the gs framework
+  gs_println("looking for pbr_basic in ./assets/pipelines/pbr_basic.sf");
+  const char* pbr_basic_path = "./assets/pipelines/pbr_basic.sf"; 
   gs_gfxt_pipeline_t pbr_pip = gs_gfxt_pipeline_load_from_file(pbr_basic_path);
   gs_gfxt_scene_t scene = {0};
   scene.pbr_pip = pbr_pip;

--- a/util/pbr_basic.sf
+++ b/util/pbr_basic.sf
@@ -1,0 +1,84 @@
+/*
+    TODO(john): Need a description of the .sf format here
+*/
+
+pipeline {
+
+    raster
+    {
+        primitive: TRIANGLES
+        index_buffer_element_size: UINT32
+    },
+
+    depth
+    {
+        func: LESS
+    },
+
+
+    shader {
+
+        vertex {
+
+            attributes {
+
+                /*
+                    Vertex layout required for this pipeline (for input assembler)
+
+                    fields:
+
+                    POSITION: 	      	float3
+                    TEXCOORD: 	      	float2
+                    TEXCOORD[0 - 12]: 	float2
+                    COLOR:    		uint8[4]
+                    NORMAL:   		float3
+                    TANGENT:  		float4
+                    JOINT:    		float4
+                    WEIGHT:   		float
+                    FLOAT: 		float
+                    FLOAT2: 		float2
+                    FLOAT3: 		float3
+                    FLOAT4: 		float4
+                */
+
+                POSITION : a_position
+                TEXCOORD : a_uv
+                COLOR    : a_color
+            },
+
+            uniforms {
+                mat4 u_mvp;
+            },
+
+            out {
+                vec2 uv;
+                vec3 position;
+            },
+
+            code {
+                void main() {
+                    gl_Position = u_mvp * vec4(a_position, 1.0);
+                    uv = a_uv;
+                    position = a_position;
+                }
+            }
+        },
+
+        fragment {
+        
+            uniforms {
+                sampler2D u_base_col_tex;
+            },
+            
+            out {
+                vec4 frag_color;
+            },
+
+            code {
+                void main() {
+                    frag_color = texture(u_base_col_tex, uv);
+                }
+            }
+        }
+    }
+}

--- a/util/pbr_basic.sf
+++ b/util/pbr_basic.sf
@@ -68,6 +68,7 @@ pipeline {
         
             uniforms {
                 sampler2D u_base_col_tex;
+                vec4 u_base_col_fact;
             },
             
             out {
@@ -76,7 +77,7 @@ pipeline {
 
             code {
                 void main() {
-                    frag_color = texture(u_base_col_tex, uv);
+                    frag_color = texture(u_base_col_tex, uv);//vec4(0.3,0.2,0.2,1.0);
                 }
             }
         }

--- a/util/pbr_basic.sf
+++ b/util/pbr_basic.sf
@@ -77,7 +77,7 @@ pipeline {
 
             code {
                 void main() {
-                    frag_color = texture(u_base_col_tex, uv);//vec4(0.3,0.2,0.2,1.0);
+                    frag_color = texture(u_base_col_tex, uv); // //
                 }
             }
         }


### PR DESCRIPTION
#### Todos copied from [the example Pull Request](https://github.com/MrFrenik/gs_examples/pull/21)

- I'd like the pbr_basic.sf pipeline to be standard to gs. (not sure the best way, so I'm just loading from the ./assets/pipelines, but in the gs/util/gs_gfxt.h this is hardcoded with gs_gfxt_scene_new()). Not so great
- gs_gfxt_pbr_free(gs_gfxt_pbr_t* pbr_info) to free unused texture data.
- Matrix transforms for child- parent nodes.
- More pbr textures and flag handling as in the gltf spec
- the black mesh actually has a vec4 base color that isn't rendered yet.
- Expand upon the pbr_basic.sf pipeline