### PR TITLE
Fix build for clang on windows

### DIFF
--- a/impl/gs_graphics_impl.h
+++ b/impl/gs_graphics_impl.h
@@ -1499,7 +1499,6 @@ gs_grapics_storage_buffer_unlock_impl(gs_handle(gs_graphics_storage_buffer_t) hn
     gsgl_data_t* ogl = (gsgl_data_t*)gs_subsystem(graphics)->user_data; 
     if (!gs_slot_array_handle_valid(ogl->storage_buffers, hndl.id)) {
         gs_log_warning("Storage buffer handle invalid: %zu", hndl.id);
-        return NULL;
     }
     gsgl_storage_buffer_t* sbo = gs_slot_array_getp(ogl->storage_buffers, hndl.id); 
 
@@ -1567,7 +1566,6 @@ gs_storage_buffer_get_data_impl(gs_handle(gs_graphics_storage_buffer_t) hndl, si
     gsgl_data_t* ogl = (gsgl_data_t*)gs_subsystem(graphics)->user_data; 
     if (!gs_slot_array_handle_valid(ogl->storage_buffers, hndl.id)) {
         gs_log_warning("Storage buffer handle invalid: %zu", hndl.id);
-        return NULL;
     }
     gsgl_storage_buffer_t* sbo = gs_slot_array_getp(ogl->storage_buffers, hndl.id);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, sbo->buffer);

--- a/impl/gs_platform_impl.h
+++ b/impl/gs_platform_impl.h
@@ -693,7 +693,7 @@ GS_API_DECL bool gs_platform_dir_exists_default_impl(const char* dir_path)
 
 GS_API_DECL int32_t gs_platform_mkdir_default_impl(const char* dir_path, int32_t opt)
 { 
-    #ifdef __MINGW32__
+    #if _WIN32
         return mkdir(dir_path);
     #else
         return mkdir(dir_path, opt);


### PR DESCRIPTION
Fixed "returning from a void function" error in `gs_grapics_storage_buffer_unlock_impl` by removing `return NULL;` line.
Changed
```
    #ifdef __MINGW32__
```
to
```
    #if _WIN32
```
which is more correct to determine signature of mkdir.