### PR TITLE
Add Windows-specific directory creation for `gs_platform_dir_exists_default_impl`

### DIFF
--- a/impl/gs_platform_impl.h
+++ b/impl/gs_platform_impl.h
@@ -718,6 +718,8 @@ GS_API_DECL int32_t gs_platform_mkdir_default_impl(const char* dir_path, int32_t
 { 
     #ifdef __MINGW32__
         return mkdir(dir_path);
+    #elif (defined GS_PLATFORM_WIN)
+        return _mkdir(dir_path);
     #else
         return mkdir(dir_path, opt);
     #endif


### PR DESCRIPTION
In msvc, turns out `mkdir` only takes a single argument so this code needs a minor tweak to handle that case. While I was looking at [the official docs](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/mkdir?view=msvc-170), also noticed that `mkdir` is deprecated in favor of `_mkdir`, so made that change as well.

**Without** this patch:
```bash
**********************************************************************
** Visual Studio 2022 Developer Command Prompt v17.14.18
** Copyright (c) 2025 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x86'

...

gs_project_template> proc\win\cl.bat
The system cannot find the file specified.
Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35219 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

main.c
C:\Users\reshen\gamedev\learn-c\gs_project_template\third_party\include\gs\impl/gs_platform_impl.h(722): error C2197: 'int mkdir(const char *)': too many arguments for call

```

**With** this patch:
```
gs_project_template> proc\win\cl.bat
Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35219 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

main.c
Microsoft (R) Incremental Linker Version 14.44.35219.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/debug
/out:App.exe
/SUBSYSTEM:CONSOLE
/NODEFAULTLIB:msvcrt.lib
/NODEFAULTLIB:LIBCMT
opengl32.lib
kernel32.lib
user32.lib
shell32.lib
vcruntime.lib
msvcrt.lib
gdi32.lib
Winmm.lib
Advapi32.lib
main.obj

gs_project_template> ls bin
App.exe  App.ilk  App.pdb  main.obj  vc140.pdb
```

p.s. Gunslinger is super cool, and your YT videos are fantastic. Appreciate you sharing your knowledge.